### PR TITLE
Add security hardening, multi-path BGP fix, and test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+.mypy_cache/
+.pytest_cache/
+bgp_snapshots.db
+routers.json
+routers.yaml
+.env
+*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BGP Route Analyzer — a single-file Python tool that SSH-polls edge routers (via Netmiko), parses BGP tables (via TextFSM), stores time-series snapshots in SQLite, and diffs pre/post change windows. Exposes both a CLI and a FastAPI REST API.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Copy `routers.json.example` to `routers.json` and fill in router credentials.
+
+## Common Commands
+
+```bash
+# CLI operations
+python bgp_route_analyzer.py --snapshot              # Poll all routers, save snapshots
+python bgp_route_analyzer.py --list                  # List stored snapshots
+python bgp_route_analyzer.py --list --router NAME    # Filter by router
+python bgp_route_analyzer.py --diff --before ID --after ID  # Diff two snapshots
+
+# API server (binds to 127.0.0.1:8000 by default)
+python bgp_route_analyzer.py --serve
+python bgp_route_analyzer.py --serve --host HOST --port PORT
+python bgp_route_analyzer.py --serve --ssl-cert cert.pem --ssl-key key.pem
+
+# Override database path or router config
+python bgp_route_analyzer.py --snapshot --db /path/to/db
+python bgp_route_analyzer.py --serve --router-config /path/to/routers.json
+
+# Linting and testing
+.venv/bin/flake8 bgp_route_analyzer.py --max-line-length 120
+.venv/bin/mypy bgp_route_analyzer.py --ignore-missing-imports
+.venv/bin/python -m pytest tests/ -v
+.venv/bin/python -m pytest tests/test_parsing.py::test_parse_returns_correct_count  # single test
+```
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BGP_ROUTER_CONFIG` | Path to router credentials JSON | `routers.json` |
+| `BGP_DB_PATH` | SQLite database file path | `bgp_snapshots.db` |
+| `BGP_ANALYZER_API_KEY` | API key for `X-API-Key` header auth | unset (auth disabled) |
+| `BGP_CORS_ORIGINS` | Comma-separated allowed CORS origins | unset (CORS disabled) |
+
+## Architecture
+
+Everything lives in `bgp_route_analyzer.py`. The file is organized into clearly separated sections:
+
+1. **Config** — Environment-driven configuration. Router credentials loaded from external `routers.json` (never committed). `_load_routers()` reads the JSON file.
+2. **Database** — SQLite schema with two tables: `snapshots` (metadata + raw output) and `prefixes` (parsed BGP attributes per snapshot). `init_db()` creates tables; `get_db()` is a context manager. All DB functions accept an optional `db_path` parameter (defaults to global `DB_PATH` at call time) for testability.
+3. **Polling** — `poll_router()` connects via Netmiko with configurable `ssh_strict`, runs `show ip bgp`, parses with TextFSM. `_parse_bgp_table()` handles the TextFSM template execution.
+4. **Snapshot storage** — `save_snapshot()`, `take_snapshots()`, `list_snapshots()`, `_snapshot_info()`, `_load_prefix_map()`.
+5. **Diff engine** — `diff_snapshots()` compares two snapshots using composite key `(network, next_hop)` to correctly handle multi-path BGP (ECMP). Detects added/removed prefixes and attribute changes (as_path, local_pref, metric, weight, origin). A next-hop change appears as one removed + one added prefix.
+6. **FastAPI API** — REST endpoints with lifespan-based startup, API key auth (optional), rate limiting (slowapi), CORS middleware, access logging, and global exception handler. Endpoints: `/health`, `POST /snapshots`, `GET /snapshots`, `GET /snapshots/{id}`, `GET /diff`.
+7. **CLI** — argparse-based `_cli()` with mutually exclusive modes: `--snapshot`, `--diff`, `--list`, `--serve`.
+
+## Key Dependencies
+
+- **netmiko** — SSH connections to network devices (Cisco IOS, IOS-XR, Arista, Junos, etc.)
+- **textfsm** — Structured parsing of CLI output via templates
+- **fastapi + uvicorn** — REST API server
+- **slowapi** — Rate limiting middleware
+- **pydantic** — Response models and validation
+- **httpx + pytest** — Testing (TestClient requires httpx)
+- **sqlite3** — Built-in, no external DB required
+
+## Testing
+
+Tests are in `tests/` with four modules:
+- `test_parsing.py` — TextFSM parser against sample Cisco IOS BGP output
+- `test_diff.py` — Diff engine including multi-path and next-hop change scenarios
+- `test_db.py` — Database CRUD, ordering, filtering, composite key loading
+- `test_api.py` — FastAPI endpoints via TestClient, including auth and validation
+
+All DB-dependent tests use `tmp_path` fixture for isolated SQLite files. API tests monkeypatch `DB_PATH` and `API_KEY`.
+
+## Vendor Customization
+
+To support non-Cisco devices, two things need changing:
+1. The command string in `poll_router()` (e.g., `show bgp ipv4 unicast` for IOS-XR)
+2. The `TEXTFSM_TEMPLATE` constant to match the vendor's output format
+
+## Database Schema
+
+- `snapshots`: id, router (name), captured_at (ISO timestamp), raw_output (full CLI output)
+- `prefixes`: id, snapshot_id (FK), network, next_hop, metric, local_pref, weight, as_path, origin

--- a/README.md
+++ b/README.md
@@ -1,0 +1,221 @@
+# BGP Route Analyzer
+
+A Python tool for automated BGP table snapshot collection, time-series storage, and pre/post change window diffing across edge routers. Reduces post-change verification from 45+ minutes of manual router diff'ing to under 2 minutes.
+
+## Features
+
+- **SSH-based polling** via Netmiko — connects to any Netmiko-supported device type (Cisco IOS, IOS-XR, Arista EOS, Junos, etc.)
+- **TextFSM parsing** — structured extraction of BGP prefix attributes (network, next_hop, as_path, local_pref, metric, weight, origin)
+- **Time-series SQLite storage** — every snapshot is timestamped and persisted; historical data is never overwritten
+- **Automated diff engine** — detects added/removed prefixes and attribute-level changes (next-hop shifts, AS path changes, local preference drift)
+- **FastAPI REST API** — NOC-facing endpoints so incident dashboards can trigger checks programmatically
+- **CLI mode** — run snapshots, diffs, and listings directly from the command line without the API server
+
+---
+
+## Requirements
+
+- Python 3.10+
+- Network access to edge routers via SSH
+- Routers must support `show ip bgp` (or equivalent — see [Customization](#customization))
+
+---
+
+## Installation
+
+```bash
+git clone <repo-url>
+cd bgp-route-analyzer
+
+python -m venv .venv
+source .venv/bin/activate       # Windows: .venv\Scripts\activate
+
+pip install -r requirements.txt
+```
+
+---
+
+## Configuration
+
+Edit the `ROUTERS` list near the top of `bgp_route_analyzer.py`:
+
+```python
+ROUTERS = [
+    {
+        "host": "10.0.0.1",
+        "username": "netops",
+        "password": "s3cr3t",          # prefer key_file in production
+        "device_type": "cisco_ios",    # netmiko device type string
+        "name": "edge-rtr-01",
+    },
+    {
+        "host": "10.0.0.2",
+        "username": "netops",
+        "key_file": "/home/netops/.ssh/id_rsa",
+        "device_type": "cisco_xe",
+        "name": "edge-rtr-02",
+    },
+]
+```
+
+The SQLite database path defaults to `bgp_snapshots.db` in the working directory. Override with `--db <path>` on the CLI or by changing `DB_PATH` in the script.
+
+---
+
+## CLI Usage
+
+### Capture a snapshot across all routers
+
+```bash
+python bgp_route_analyzer.py --snapshot
+# Saved snapshots: [1, 2]
+```
+
+### List stored snapshots
+
+```bash
+python bgp_route_analyzer.py --list
+
+# Filter by router
+python bgp_route_analyzer.py --list --router edge-rtr-01
+```
+
+Example output:
+```
+[   1]  edge-rtr-01                     2026-03-04T18:00:00+00:00
+[   2]  edge-rtr-02                     2026-03-04T18:00:01+00:00
+[   3]  edge-rtr-01                     2026-03-04T18:45:00+00:00
+[   4]  edge-rtr-02                     2026-03-04T18:45:01+00:00
+```
+
+### Diff two snapshots (pre/post change window)
+
+```bash
+python bgp_route_analyzer.py --diff --before 1 --after 3
+```
+
+Example output:
+```json
+{
+  "before_snapshot_id": 1,
+  "after_snapshot_id": 3,
+  "summary": {
+    "added": 1,
+    "removed": 0,
+    "changed": 2
+  },
+  "added": [
+    { "network": "192.0.2.0/24", "next_hop": "10.1.1.1", "as_path": "65001 65002", ... }
+  ],
+  "removed": [],
+  "changed": [
+    {
+      "network": "203.0.113.0/24",
+      "changes": {
+        "next_hop": { "before": "10.1.1.1", "after": "10.2.2.2" },
+        "as_path":  { "before": "65001",    "after": "65001 65099" }
+      }
+    }
+  ]
+}
+```
+
+### Start the API server
+
+```bash
+python bgp_route_analyzer.py --serve
+# or with custom bind address:
+python bgp_route_analyzer.py --serve --host 0.0.0.0 --port 8080
+```
+
+---
+
+## REST API
+
+Once the server is running, the interactive docs are available at `http://localhost:8000/docs`.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/health` | Liveness check |
+| `POST` | `/snapshots` | Poll all routers and store snapshots |
+| `GET` | `/snapshots` | List snapshots (`?router=name&limit=20`) |
+| `GET` | `/snapshots/{id}` | Get snapshot metadata + full prefix table |
+| `GET` | `/diff?before=1&after=3` | Diff two snapshots |
+
+### Example: trigger a snapshot from curl
+
+```bash
+curl -X POST http://localhost:8000/snapshots
+# {"snapshot_ids":[5,6],"message":"Captured 2 snapshot(s)."}
+```
+
+### Example: run a diff
+
+```bash
+curl "http://localhost:8000/diff?before=5&after=6" | jq .
+```
+
+---
+
+## Typical Change Window Workflow
+
+```
+1. Pre-change:   python bgp_route_analyzer.py --snapshot
+                 # note the snapshot IDs printed (e.g. 7, 8)
+
+2. Perform change window work
+
+3. Post-change:  python bgp_route_analyzer.py --snapshot
+                 # note the snapshot IDs printed (e.g. 9, 10)
+
+4. Verify:       python bgp_route_analyzer.py --diff --before 7 --after 9
+                 python bgp_route_analyzer.py --diff --before 8 --after 10
+```
+
+Any route leaks, unexpected next-hop changes, or missing prefixes are reported immediately in the diff output.
+
+---
+
+## Customization
+
+### Supporting other vendors / commands
+
+The `TEXTFSM_TEMPLATE` constant in `bgp_route_analyzer.py` and the `show ip bgp` command in `poll_router()` are the only vendor-specific pieces. To support IOS-XR, Arista EOS, or Junos:
+
+1. Change the command string in `poll_router()` (e.g. `show bgp ipv4 unicast` for IOS-XR)
+2. Update `TEXTFSM_TEMPLATE` to match the output format, or use a template from the [ntc-templates](https://github.com/networktocode/ntc-templates) library
+
+### Using ntc-templates
+
+```bash
+pip install ntc-templates
+```
+
+```python
+from ntc_templates.parse import parse_output
+
+def _parse_bgp_table(raw_output: str, platform: str = "cisco_ios") -> list[dict]:
+    return parse_output(platform=platform, command="show ip bgp", data=raw_output)
+```
+
+### Externalizing router config
+
+For production use, move the `ROUTERS` list to a YAML or JSON file and load it at startup, or pull credentials from AWS Secrets Manager / HashiCorp Vault.
+
+---
+
+## Project Structure
+
+```
+bgp-route-analyzer/
+├── bgp_route_analyzer.py   # Main script — polling, storage, diff, API, CLI
+├── requirements.txt        # Python dependencies
+├── README.md
+└── bgp_snapshots.db        # SQLite database (created on first run)
+```
+
+---
+
+## License
+
+MIT

--- a/bgp_route_analyzer.py
+++ b/bgp_route_analyzer.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+BGP Route Analysis Tool
+-----------------------
+Polls edge routers via SSH using Netmiko, parses BGP tables with TextFSM,
+stores snapshots in a time-series SQLite database, and compares prefix
+advertisements before/after a change window.
+
+Exposes a REST API via FastAPI so the NOC team can trigger checks from
+their incident dashboard.
+
+Configuration:
+    Router credentials:  routers.json  (see routers.json.example)
+    Environment vars:
+        BGP_ROUTER_CONFIG    - path to router config JSON  (default: routers.json)
+        BGP_DB_PATH          - SQLite database path         (default: bgp_snapshots.db)
+        BGP_ANALYZER_API_KEY - API key for authentication   (optional, disables auth if unset)
+        BGP_CORS_ORIGINS     - comma-separated CORS origins (optional)
+
+Usage:
+    python bgp_route_analyzer.py --snapshot
+    python bgp_route_analyzer.py --diff --before <id> --after <id>
+    python bgp_route_analyzer.py --serve
+"""
+
+import argparse
+import io
+import json
+import logging
+import os
+import sqlite3
+import sys
+import textwrap
+from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+import textfsm
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Security
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.security import APIKeyHeader
+from netmiko import ConnectHandler, NetmikoAuthenticationException, NetmikoTimeoutException
+from pydantic import BaseModel
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+log = logging.getLogger("bgp_analyzer")
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+DB_PATH = Path(os.environ.get("BGP_DB_PATH", "bgp_snapshots.db"))
+API_KEY = os.environ.get("BGP_ANALYZER_API_KEY")
+CORS_ORIGINS = [o.strip() for o in os.environ.get("BGP_CORS_ORIGINS", "").split(",") if o.strip()]
+
+
+def _load_routers(config_path: str | None = None) -> list[dict]:
+    """Load router configuration from an external JSON file."""
+    path = config_path or os.environ.get("BGP_ROUTER_CONFIG", "routers.json")
+    if not Path(path).exists():
+        return []
+    with open(path) as f:
+        return json.load(f)
+
+
+ROUTERS: list[dict] = _load_routers()
+
+# TextFSM template for "show ip bgp" (Cisco IOS style).
+# Expand or swap out per-vendor as needed.
+TEXTFSM_TEMPLATE = textwrap.dedent("""\
+    Value NETWORK (\\S+)
+    Value NEXT_HOP (\\S+)
+    Value METRIC (\\d*)
+    Value LOCAL_PREF (\\d*)
+    Value WEIGHT (\\d+)
+    Value AS_PATH (.*)
+    Value STATUS ([sdh>irSR*]*)
+    Value ORIGIN ([ie?])
+
+    Start
+      ^\\s+${NETWORK}\\s+${NEXT_HOP}\\s+${METRIC}\\s+${LOCAL_PREF}\\s+${WEIGHT}\\s+${AS_PATH}\\s+${ORIGIN} -> Record
+      ^\\*>\\s*${NETWORK}\\s+${NEXT_HOP}\\s+${METRIC}\\s+${LOCAL_PREF}\\s+${WEIGHT}\\s+${AS_PATH}\\s+${ORIGIN} -> Record
+      ^. -> Continue
+
+    EOF
+""")
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+
+def init_db(db_path: Path | None = None) -> None:
+    """Create tables if they don't exist."""
+    if db_path is None:
+        db_path = DB_PATH
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS snapshots (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                router      TEXT NOT NULL,
+                captured_at TEXT NOT NULL,
+                raw_output  TEXT NOT NULL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS prefixes (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                snapshot_id INTEGER NOT NULL REFERENCES snapshots(id),
+                network     TEXT NOT NULL,
+                next_hop    TEXT,
+                metric      TEXT,
+                local_pref  TEXT,
+                weight      TEXT,
+                as_path     TEXT,
+                origin      TEXT
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_prefixes_snapshot ON prefixes(snapshot_id)")
+        conn.commit()
+
+
+@contextmanager
+def get_db(db_path: Path | None = None) -> Generator[sqlite3.Connection, None, None]:
+    if db_path is None:
+        db_path = DB_PATH
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Device polling
+# ---------------------------------------------------------------------------
+
+
+def poll_router(router_cfg: dict) -> tuple[str, list[dict]]:
+    """
+    SSH into a router, run 'show ip bgp', parse with TextFSM.
+    Returns (raw_output, list_of_prefix_dicts).
+    """
+    log.info("Connecting to %s (%s)", router_cfg["name"], router_cfg["host"])
+    try:
+        connection = ConnectHandler(
+            host=router_cfg["host"],
+            username=router_cfg["username"],
+            password=router_cfg.get("password", ""),
+            device_type=router_cfg["device_type"],
+            key_file=router_cfg.get("key_file"),
+            ssh_strict=router_cfg.get("ssh_strict", False),
+            timeout=30,
+        )
+    except NetmikoAuthenticationException:
+        log.error("Auth failed for %s (%s)", router_cfg["name"], router_cfg["host"])
+        raise RuntimeError(f"Authentication failed for {router_cfg['name']}") from None
+    except NetmikoTimeoutException:
+        log.error("Timeout connecting to %s (%s)", router_cfg["name"], router_cfg["host"])
+        raise RuntimeError(f"Timeout connecting to {router_cfg['name']}") from None
+
+    try:
+        raw = connection.send_command("show ip bgp", read_timeout=60)
+    finally:
+        connection.disconnect()
+
+    prefixes = _parse_bgp_table(raw)
+    log.info("  -> %d prefixes parsed from %s", len(prefixes), router_cfg["name"])
+    return raw, prefixes
+
+
+def _parse_bgp_table(raw_output: str) -> list[dict]:
+    """Parse raw 'show ip bgp' output using TextFSM."""
+    template_fh = io.StringIO(TEXTFSM_TEMPLATE)
+    fsm = textfsm.TextFSM(template_fh)
+    rows = fsm.ParseText(raw_output)
+    headers = [h.lower() for h in fsm.header]
+    return [dict(zip(headers, row)) for row in rows if any(row)]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot storage
+# ---------------------------------------------------------------------------
+
+
+def save_snapshot(
+    router_name: str,
+    raw_output: str,
+    prefixes: list[dict],
+    db_path: Path | None = None,
+) -> int:
+    """Persist a snapshot and its prefixes; return the snapshot id."""
+    if db_path is None:
+        db_path = DB_PATH
+    captured_at = datetime.now(timezone.utc).isoformat()
+    with get_db(db_path) as conn:
+        cur = conn.execute(
+            "INSERT INTO snapshots (router, captured_at, raw_output) VALUES (?, ?, ?)",
+            (router_name, captured_at, raw_output),
+        )
+        snap_id = cur.lastrowid
+        assert snap_id is not None, "INSERT did not return a row id"
+        conn.executemany(
+            """INSERT INTO prefixes
+               (snapshot_id, network, next_hop, metric, local_pref, weight, as_path, origin)
+               VALUES (:snap_id, :network, :next_hop, :metric, :local_pref, :weight, :as_path, :origin)""",
+            [{**p, "snap_id": snap_id} for p in prefixes],
+        )
+    log.info("Saved snapshot id=%d for router=%s at %s", snap_id, router_name, captured_at)
+    return snap_id
+
+
+def take_snapshots(
+    routers: list[dict] | None = None,
+    db_path: Path | None = None,
+) -> list[int]:
+    """Poll all routers and save snapshots. Returns list of snapshot ids."""
+    if routers is None:
+        routers = ROUTERS
+    if db_path is None:
+        db_path = DB_PATH
+    init_db(db_path)
+    snap_ids = []
+    for router_cfg in routers:
+        try:
+            raw, prefixes = poll_router(router_cfg)
+            sid = save_snapshot(router_cfg["name"], raw, prefixes, db_path)
+            snap_ids.append(sid)
+        except (RuntimeError, sqlite3.Error) as exc:
+            log.error("Failed to snapshot %s: %s", router_cfg.get("name", "?"), exc)
+    return snap_ids
+
+
+# ---------------------------------------------------------------------------
+# Diff / comparison
+# ---------------------------------------------------------------------------
+
+
+def _load_prefix_map(
+    snapshot_id: int,
+    db_path: Path | None = None,
+) -> dict[tuple[str, str], dict]:
+    """Return {(network, next_hop): prefix_dict} for a given snapshot.
+
+    Uses a composite key so multiple BGP paths per prefix are tracked
+    correctly (e.g. ECMP, backup paths).
+    """
+    if db_path is None:
+        db_path = DB_PATH
+    with get_db(db_path) as conn:
+        rows = conn.execute(
+            "SELECT network, next_hop, metric, local_pref, weight, as_path, origin "
+            "FROM prefixes WHERE snapshot_id = ?",
+            (snapshot_id,),
+        ).fetchall()
+    return {(row["network"], row["next_hop"] or ""): dict(row) for row in rows}
+
+
+def diff_snapshots(
+    before_id: int,
+    after_id: int,
+    db_path: Path | None = None,
+) -> dict:
+    """
+    Compare two snapshots and return a structured diff:
+      - added:    prefixes present in after but not before
+      - removed:  prefixes present in before but not after
+      - changed:  prefixes present in both but with different attributes
+    """
+    if db_path is None:
+        db_path = DB_PATH
+    before = _load_prefix_map(before_id, db_path)
+    after = _load_prefix_map(after_id, db_path)
+
+    before_keys = set(before.keys())
+    after_keys = set(after.keys())
+
+    added = [after[k] for k in sorted(after_keys - before_keys)]
+    removed = [before[k] for k in sorted(before_keys - after_keys)]
+
+    changed = []
+    for key in sorted(before_keys & after_keys):
+        b, a = before[key], after[key]
+        diffs = {
+            field: {"before": b[field], "after": a[field]}
+            for field in ("as_path", "local_pref", "metric", "weight", "origin")
+            if b.get(field) != a.get(field)
+        }
+        if diffs:
+            changed.append({"network": key[0], "next_hop": key[1], "changes": diffs})
+
+    return {
+        "before_snapshot_id": before_id,
+        "after_snapshot_id": after_id,
+        "summary": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+        },
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+    }
+
+
+def _snapshot_info(snapshot_id: int, db_path: Path | None = None) -> dict | None:
+    if db_path is None:
+        db_path = DB_PATH
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT id, router, captured_at FROM snapshots WHERE id = ?", (snapshot_id,)
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def list_snapshots(
+    router: str | None = None,
+    limit: int = 20,
+    db_path: Path | None = None,
+) -> list[dict]:
+    if db_path is None:
+        db_path = DB_PATH
+    query = "SELECT id, router, captured_at FROM snapshots"
+    params: list = []
+    if router:
+        query += " WHERE router = ?"
+        params.append(router)
+    query += " ORDER BY id DESC LIMIT ?"
+    params.append(limit)
+    with get_db(db_path) as conn:
+        rows = conn.execute(query, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class SnapshotResponse(BaseModel):
+    snapshot_ids: list[int]
+    message: str
+
+
+class PrefixInfo(BaseModel):
+    network: str
+    next_hop: str | None = None
+    metric: str | None = None
+    local_pref: str | None = None
+    weight: str | None = None
+    as_path: str | None = None
+    origin: str | None = None
+
+
+class AttributeChange(BaseModel):
+    before: str | None = None
+    after: str | None = None
+
+
+class PrefixChange(BaseModel):
+    network: str
+    next_hop: str | None = None
+    changes: dict[str, AttributeChange]
+
+
+class DiffSummary(BaseModel):
+    added: int
+    removed: int
+    changed: int
+
+
+class DiffResponse(BaseModel):
+    before_snapshot_id: int
+    after_snapshot_id: int
+    summary: DiffSummary
+    added: list[PrefixInfo]
+    removed: list[PrefixInfo]
+    changed: list[PrefixChange]
+
+
+# ---------------------------------------------------------------------------
+# FastAPI REST layer
+# ---------------------------------------------------------------------------
+
+# Rate limiter
+limiter = Limiter(key_func=get_remote_address)
+
+# Auth dependency
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(key: str | None = Security(api_key_header)) -> None:
+    """Verify API key if BGP_ANALYZER_API_KEY is configured."""
+    if API_KEY is None:
+        return
+    if key != API_KEY:
+        raise HTTPException(status_code=403, detail="Invalid or missing API key")
+
+
+# Access logging middleware
+class AccessLogMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        client = request.client.host if request.client else "unknown"
+        log.info("%s %s from %s", request.method, request.url.path, client)
+        response = await call_next(request)
+        return response
+
+
+@asynccontextmanager
+async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
+    init_db()
+    if not API_KEY:
+        log.warning("BGP_ANALYZER_API_KEY not set -- API authentication is disabled")
+    if not ROUTERS:
+        log.warning("No routers configured -- set BGP_ROUTER_CONFIG or create routers.json")
+    yield
+
+
+app = FastAPI(
+    title="BGP Route Analyzer",
+    description="NOC-facing API to snapshot and diff BGP tables across edge routers.",
+    version="1.0.0",
+    dependencies=[Depends(verify_api_key)],
+    lifespan=lifespan,
+)
+
+# Middleware & exception handlers
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
+app.add_middleware(AccessLogMiddleware)
+
+if CORS_ORIGINS:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=CORS_ORIGINS,
+        allow_methods=["GET", "POST"],
+        allow_headers=["X-API-Key"],
+    )
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    log.error("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
+
+
+@app.post("/snapshots", response_model=SnapshotResponse)
+@limiter.limit("5/minute")
+def api_take_snapshots(request: Request) -> SnapshotResponse:
+    """Poll all configured routers and store BGP table snapshots."""
+    if not ROUTERS:
+        raise HTTPException(status_code=503, detail="No routers configured.")
+    snap_ids = take_snapshots()
+    return SnapshotResponse(
+        snapshot_ids=snap_ids,
+        message=f"Captured {len(snap_ids)} snapshot(s).",
+    )
+
+
+@app.get("/snapshots")
+def api_list_snapshots(
+    router: str | None = Query(None, pattern=r"^[a-zA-Z0-9._-]{1,64}$", description="Filter by router name"),
+    limit: int = Query(20, ge=1, le=200),
+) -> list[dict]:
+    """List stored snapshots, newest first."""
+    return list_snapshots(router=router, limit=limit)
+
+
+@app.get("/snapshots/{snapshot_id}")
+def api_get_snapshot(snapshot_id: int) -> dict:
+    """Return metadata for a specific snapshot."""
+    info = _snapshot_info(snapshot_id)
+    if not info:
+        raise HTTPException(status_code=404, detail=f"Snapshot {snapshot_id} not found.")
+    prefixes = _load_prefix_map(snapshot_id)
+    return {"snapshot": info, "prefix_count": len(prefixes), "prefixes": list(prefixes.values())}
+
+
+@app.get("/diff", response_model=DiffResponse)
+def api_diff(
+    before: int = Query(..., description="Snapshot ID before change window"),
+    after: int = Query(..., description="Snapshot ID after change window"),
+) -> dict:
+    """
+    Compare two snapshots. Highlights added/removed prefixes and path changes.
+    Ideal for post-change verification — catches route leaks and unexpected path shifts.
+    """
+    for sid in (before, after):
+        if not _snapshot_info(sid):
+            raise HTTPException(status_code=404, detail=f"Snapshot {sid} not found.")
+    return diff_snapshots(before, after)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="BGP Route Analysis Tool")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--snapshot", action="store_true", help="Poll routers and save snapshots")
+    group.add_argument("--diff", action="store_true", help="Diff two snapshots")
+    group.add_argument("--list", action="store_true", help="List stored snapshots")
+    group.add_argument("--serve", action="store_true", help="Start FastAPI server")
+
+    parser.add_argument("--before", type=int, help="Snapshot ID before change window (for --diff)")
+    parser.add_argument("--after", type=int, help="Snapshot ID after change window (for --diff)")
+    parser.add_argument("--router", help="Filter by router name (for --list)")
+    parser.add_argument("--router-config", help="Path to router config JSON file")
+    parser.add_argument("--db", default=str(DB_PATH), help="SQLite database path")
+    parser.add_argument("--host", default="127.0.0.1", help="API server host (for --serve)")
+    parser.add_argument("--port", type=int, default=8000, help="API server port (for --serve)")
+    parser.add_argument("--ssl-cert", help="Path to SSL certificate (for --serve)")
+    parser.add_argument("--ssl-key", help="Path to SSL private key (for --serve)")
+
+    args = parser.parse_args()
+
+    # Validate database path
+    db = Path(args.db)
+    if not db.parent.exists():
+        print(f"ERROR: Parent directory {db.parent} does not exist.", file=sys.stderr)
+        sys.exit(1)
+    init_db(db)
+
+    # Load router config override if specified
+    if args.router_config:
+        ROUTERS.clear()
+        ROUTERS.extend(_load_routers(args.router_config))
+
+    if args.snapshot:
+        if not ROUTERS:
+            print("ERROR: No routers configured. Create routers.json or use --router-config.", file=sys.stderr)
+            sys.exit(1)
+        ids = take_snapshots(db_path=db)
+        print(f"Snapshots saved: {ids}")
+
+    elif args.diff:
+        if not args.before or not args.after:
+            parser.error("--diff requires --before and --after snapshot IDs")
+        result = diff_snapshots(args.before, args.after, db_path=db)
+        print(json.dumps(result, indent=2))
+
+    elif args.list:
+        rows = list_snapshots(router=args.router, db_path=db)
+        for r in rows:
+            print(f"  [{r['id']:4d}]  {r['router']:30s}  {r['captured_at']}")
+
+    elif args.serve:
+        ssl_kwargs: dict = {}
+        if args.ssl_cert and args.ssl_key:
+            ssl_kwargs["ssl_certfile"] = args.ssl_cert
+            ssl_kwargs["ssl_keyfile"] = args.ssl_key
+        uvicorn.run(app, host=args.host, port=args.port, **ssl_kwargs)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+netmiko>=4.3.0
+textfsm>=1.1.3
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+pydantic>=2.0.0
+slowapi>=0.1.9
+httpx>=0.27.0
+pytest>=8.0.0

--- a/routers.json.example
+++ b/routers.json.example
@@ -1,0 +1,18 @@
+[
+    {
+        "host": "10.0.0.1",
+        "username": "netops",
+        "password": "changeme",
+        "device_type": "cisco_ios",
+        "name": "edge-rtr-01",
+        "ssh_strict": false
+    },
+    {
+        "host": "10.0.0.2",
+        "username": "netops",
+        "key_file": "/home/netops/.ssh/id_rsa",
+        "device_type": "cisco_xe",
+        "name": "edge-rtr-02",
+        "ssh_strict": true
+    }
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from pathlib import Path
+
+from bgp_route_analyzer import init_db
+
+
+@pytest.fixture
+def test_db(tmp_path: Path) -> Path:
+    """Create a temporary database for testing."""
+    db = tmp_path / "test.db"
+    init_db(db)
+    return db

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,128 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from bgp_route_analyzer import app, init_db, save_snapshot
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch):
+    db = tmp_path / "api_test.db"
+    monkeypatch.setattr("bgp_route_analyzer.DB_PATH", db)
+    monkeypatch.setattr("bgp_route_analyzer.API_KEY", None)  # disable auth for tests
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def seeded_client(tmp_path: Path, monkeypatch):
+    """Client with pre-seeded snapshot data."""
+    db = tmp_path / "api_test.db"
+    monkeypatch.setattr("bgp_route_analyzer.DB_PATH", db)
+    monkeypatch.setattr("bgp_route_analyzer.API_KEY", None)
+    init_db(db)
+
+    prefixes_before = [
+        {"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65001", "origin": "i"},
+    ]
+    prefixes_after = [
+        {"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65001 65099", "origin": "i"},
+        {"network": "192.168.1.0/24", "next_hop": "2.2.2.2", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65002", "origin": "i"},
+    ]
+    save_snapshot("rtr1", "raw1", prefixes_before, db)
+    save_snapshot("rtr1", "raw2", prefixes_after, db)
+
+    with TestClient(app) as c:
+        yield c
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert "timestamp" in data
+
+
+def test_list_snapshots_empty(client):
+    resp = client.get("/snapshots")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_snapshot_not_found(client):
+    resp = client.get("/snapshots/999")
+    assert resp.status_code == 404
+
+
+def test_list_snapshots_with_data(seeded_client):
+    resp = seeded_client.get("/snapshots")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+
+def test_get_snapshot(seeded_client):
+    resp = seeded_client.get("/snapshots/1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["snapshot"]["router"] == "rtr1"
+    assert data["prefix_count"] == 1
+
+
+def test_diff_endpoint(seeded_client):
+    resp = seeded_client.get("/diff?before=1&after=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["added"] == 1
+    assert data["summary"]["changed"] == 1
+
+
+def test_diff_not_found(client):
+    resp = client.get("/diff?before=999&after=998")
+    assert resp.status_code == 404
+
+
+def test_list_snapshots_router_filter(seeded_client):
+    resp = seeded_client.get("/snapshots?router=rtr1")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    resp = seeded_client.get("/snapshots?router=nonexistent")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 0
+
+
+def test_list_snapshots_invalid_router_name(client):
+    resp = client.get("/snapshots?router=;DROP TABLE")
+    assert resp.status_code == 422  # validation error
+
+
+def test_post_snapshots_no_routers(client, monkeypatch):
+    monkeypatch.setattr("bgp_route_analyzer.ROUTERS", [])
+    resp = client.post("/snapshots")
+    assert resp.status_code == 503
+
+
+def test_api_key_auth_required(tmp_path: Path, monkeypatch):
+    db = tmp_path / "auth_test.db"
+    monkeypatch.setattr("bgp_route_analyzer.DB_PATH", db)
+    monkeypatch.setattr("bgp_route_analyzer.API_KEY", "test-secret-key")
+
+    with TestClient(app) as c:
+        # No key -> 403
+        resp = c.get("/health")
+        assert resp.status_code == 403
+
+        # Wrong key -> 403
+        resp = c.get("/health", headers={"X-API-Key": "wrong"})
+        assert resp.status_code == 403
+
+        # Correct key -> 200
+        resp = c.get("/health", headers={"X-API-Key": "test-secret-key"})
+        assert resp.status_code == 200

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from bgp_route_analyzer import (
+    _load_prefix_map,
+    _snapshot_info,
+    init_db,
+    list_snapshots,
+    save_snapshot,
+)
+
+
+def test_init_db_creates_tables(tmp_path: Path):
+    db = tmp_path / "new.db"
+    init_db(db)
+    assert db.exists()
+
+
+def test_init_db_idempotent(test_db: Path):
+    init_db(test_db)  # second call should not raise
+    init_db(test_db)  # third call should not raise
+
+
+def test_save_and_retrieve_snapshot(test_db: Path):
+    prefixes = [
+        {"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65001", "origin": "i"},
+    ]
+    sid = save_snapshot("rtr1", "raw output here", prefixes, test_db)
+    assert sid is not None
+    assert sid > 0
+
+    info = _snapshot_info(sid, test_db)
+    assert info is not None
+    assert info["router"] == "rtr1"
+
+
+def test_snapshot_info_not_found(test_db: Path):
+    assert _snapshot_info(9999, test_db) is None
+
+
+def test_list_snapshots_returns_newest_first(test_db: Path):
+    p = [{"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "",
+          "local_pref": "", "weight": "0", "as_path": "", "origin": "i"}]
+    save_snapshot("rtr1", "raw1", p, test_db)
+    save_snapshot("rtr2", "raw2", p, test_db)
+    save_snapshot("rtr3", "raw3", p, test_db)
+
+    rows = list_snapshots(db_path=test_db)
+    assert len(rows) == 3
+    assert rows[0]["router"] == "rtr3"  # newest first
+
+
+def test_list_snapshots_filter_by_router(test_db: Path):
+    p = [{"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "",
+          "local_pref": "", "weight": "0", "as_path": "", "origin": "i"}]
+    save_snapshot("rtr1", "raw1", p, test_db)
+    save_snapshot("rtr2", "raw2", p, test_db)
+
+    rows = list_snapshots(router="rtr1", db_path=test_db)
+    assert len(rows) == 1
+    assert rows[0]["router"] == "rtr1"
+
+
+def test_load_prefix_map_composite_key(test_db: Path):
+    prefixes = [
+        {"network": "10.0.0.0/8", "next_hop": "1.1.1.1", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65001", "origin": "i"},
+        {"network": "10.0.0.0/8", "next_hop": "2.2.2.2", "metric": "0",
+         "local_pref": "100", "weight": "0", "as_path": "65002", "origin": "i"},
+    ]
+    sid = save_snapshot("rtr1", "raw", prefixes, test_db)
+    pmap = _load_prefix_map(sid, test_db)
+
+    # Both paths should be present (composite key)
+    assert len(pmap) == 2
+    assert ("10.0.0.0/8", "1.1.1.1") in pmap
+    assert ("10.0.0.0/8", "2.2.2.2") in pmap

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from bgp_route_analyzer import diff_snapshots, init_db, save_snapshot
+
+
+def _make_prefix(network: str, next_hop: str = "1.1.1.1", **overrides) -> dict:
+    base = {
+        "network": network,
+        "next_hop": next_hop,
+        "metric": "0",
+        "local_pref": "100",
+        "weight": "0",
+        "as_path": "65001",
+        "origin": "i",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_diff_detects_added_prefix(test_db: Path):
+    id1 = save_snapshot("rtr1", "raw1", [_make_prefix("10.0.0.0/8")], test_db)
+    id2 = save_snapshot("rtr1", "raw2", [
+        _make_prefix("10.0.0.0/8"),
+        _make_prefix("192.168.1.0/24", "2.2.2.2"),
+    ], test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    assert result["summary"]["added"] == 1
+    assert result["summary"]["removed"] == 0
+    assert result["added"][0]["network"] == "192.168.1.0/24"
+
+
+def test_diff_detects_removed_prefix(test_db: Path):
+    id1 = save_snapshot("rtr1", "raw1", [
+        _make_prefix("10.0.0.0/8"),
+        _make_prefix("172.16.0.0/12", "2.2.2.2"),
+    ], test_db)
+    id2 = save_snapshot("rtr1", "raw2", [_make_prefix("10.0.0.0/8")], test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    assert result["summary"]["removed"] == 1
+    assert result["removed"][0]["network"] == "172.16.0.0/12"
+
+
+def test_diff_detects_changed_attribute(test_db: Path):
+    id1 = save_snapshot("rtr1", "raw1", [_make_prefix("10.0.0.0/8", as_path="65001")], test_db)
+    id2 = save_snapshot("rtr1", "raw2", [_make_prefix("10.0.0.0/8", as_path="65001 65099")], test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    assert result["summary"]["changed"] == 1
+    assert result["changed"][0]["network"] == "10.0.0.0/8"
+    assert result["changed"][0]["changes"]["as_path"]["before"] == "65001"
+    assert result["changed"][0]["changes"]["as_path"]["after"] == "65001 65099"
+
+
+def test_diff_no_changes(test_db: Path):
+    prefixes = [_make_prefix("10.0.0.0/8"), _make_prefix("172.16.0.0/12", "2.2.2.2")]
+    id1 = save_snapshot("rtr1", "raw1", prefixes, test_db)
+    id2 = save_snapshot("rtr1", "raw2", prefixes, test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    assert result["summary"]["added"] == 0
+    assert result["summary"]["removed"] == 0
+    assert result["summary"]["changed"] == 0
+
+
+def test_diff_handles_multi_path(test_db: Path):
+    """Multiple paths for the same network should be tracked independently."""
+    id1 = save_snapshot("rtr1", "raw1", [
+        _make_prefix("10.0.0.0/8", "1.1.1.1"),
+        _make_prefix("10.0.0.0/8", "2.2.2.2"),
+    ], test_db)
+    id2 = save_snapshot("rtr1", "raw2", [
+        _make_prefix("10.0.0.0/8", "1.1.1.1"),
+        _make_prefix("10.0.0.0/8", "3.3.3.3"),
+    ], test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    # Path via 2.2.2.2 removed, path via 3.3.3.3 added
+    assert result["summary"]["removed"] == 1
+    assert result["summary"]["added"] == 1
+    assert result["removed"][0]["next_hop"] == "2.2.2.2"
+    assert result["added"][0]["next_hop"] == "3.3.3.3"
+
+
+def test_diff_next_hop_change_shows_as_add_remove(test_db: Path):
+    """A next-hop change for a prefix shows as one removed + one added."""
+    id1 = save_snapshot("rtr1", "raw1", [_make_prefix("10.0.0.0/8", "1.1.1.1")], test_db)
+    id2 = save_snapshot("rtr1", "raw2", [_make_prefix("10.0.0.0/8", "2.2.2.2")], test_db)
+
+    result = diff_snapshots(id1, id2, test_db)
+    assert result["summary"]["added"] == 1
+    assert result["summary"]["removed"] == 1
+    assert result["summary"]["changed"] == 0

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,61 @@
+from bgp_route_analyzer import _parse_bgp_table
+
+SAMPLE_BGP_OUTPUT = """\
+BGP table version is 5, local router ID is 10.0.0.1
+Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 10.0.0.0/8       192.168.1.1              0    100      0 65001 i
+*> 172.16.0.0/12    192.168.1.2            100    200     10 65002 65003 i
+*> 192.168.0.0/16   0.0.0.0                  0    100      0 i
+"""
+
+
+def test_parse_returns_correct_count():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    assert len(result) == 3
+
+
+def test_parse_extracts_network():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    networks = [r["network"] for r in result]
+    assert "10.0.0.0/8" in networks
+    assert "172.16.0.0/12" in networks
+    assert "192.168.0.0/16" in networks
+
+
+def test_parse_extracts_next_hop():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    first = next(r for r in result if r["network"] == "10.0.0.0/8")
+    assert first["next_hop"] == "192.168.1.1"
+
+
+def test_parse_extracts_as_path():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    multi_hop = next(r for r in result if r["network"] == "172.16.0.0/12")
+    assert "65002" in multi_hop["as_path"]
+    assert "65003" in multi_hop["as_path"]
+
+
+def test_parse_extracts_origin():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    first = next(r for r in result if r["network"] == "10.0.0.0/8")
+    assert first["origin"] == "i"
+
+
+def test_parse_extracts_metrics():
+    result = _parse_bgp_table(SAMPLE_BGP_OUTPUT)
+    multi_hop = next(r for r in result if r["network"] == "172.16.0.0/12")
+    assert multi_hop["metric"] == "100"
+    assert multi_hop["local_pref"] == "200"
+    assert multi_hop["weight"] == "10"
+
+
+def test_parse_empty_input():
+    assert _parse_bgp_table("") == []
+
+
+def test_parse_no_routes():
+    result = _parse_bgp_table("BGP table version is 1\n\n")
+    assert result == []


### PR DESCRIPTION
## Summary

- **Security hardening**: API key auth, rate limiting (slowapi), CORS middleware, sanitized error messages, SSH strict mode, 127.0.0.1 default bind, TLS CLI support, access logging, global exception handler
- **Multi-path BGP correctness fix**: Changed prefix map key from `network` to `(network, next_hop)` composite key so ECMP/backup paths are tracked independently
- **Config externalization**: Router credentials moved from source to `routers.json`, all settings via environment variables
- **Test suite**: 32 tests across 4 modules (parsing, diff, DB, API) — all passing with flake8 and mypy clean

## Test plan

- [x] `flake8 bgp_route_analyzer.py --max-line-length 120` — 0 violations
- [x] `mypy bgp_route_analyzer.py --ignore-missing-imports` — 0 errors
- [x] `pytest tests/ -v` — 32/32 passed
- [ ] Manual: set `BGP_ANALYZER_API_KEY` and verify auth enforcement
- [ ] Manual: test with real router credentials via `routers.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)