### PR TITLE
Add CI workflow with pytest, flake8, mypy, and ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 mypy ruff
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Flake8
+        run: flake8 bgp_route_analyzer.py --max-line-length 120
+
+      - name: Mypy
+        run: mypy bgp_route_analyzer.py --ignore-missing-imports
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 mypy ruff
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/bgp_route_analyzer.py
+++ b/bgp_route_analyzer.py
@@ -41,12 +41,13 @@ import textwrap
 import threading
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import textfsm
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Path as PathParam, Query, Request, Security
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Security
+from fastapi import Path as PathParam
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
@@ -316,7 +317,7 @@ def _parse_bgp_table(raw_output: str) -> list[dict]:
     fsm = textfsm.TextFSM(template_fh)
     rows = fsm.ParseText(raw_output)
     headers = [h.lower() for h in fsm.header]
-    return [dict(zip(headers, row)) for row in rows if any(row)]
+    return [dict(zip(headers, row, strict=False)) for row in rows if any(row)]
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +334,7 @@ def save_snapshot(
     """Persist a snapshot and its prefixes; return the snapshot id."""
     if db_path is None:
         db_path = DB_PATH
-    captured_at = datetime.now(timezone.utc).isoformat()
+    captured_at = datetime.now(UTC).isoformat()
     with get_db(db_path) as conn:
         cur = conn.execute(
             "INSERT INTO snapshots (router, captured_at, raw_output) VALUES (?, ?, ?)",
@@ -392,7 +393,7 @@ def purge_old_snapshots(days: int, db_path: Path | None = None) -> int:
     """Delete snapshots older than N days. Returns count of deleted snapshots."""
     if db_path is None:
         db_path = DB_PATH
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
     with get_db(db_path) as conn:
         conn.execute(
             "DELETE FROM prefixes WHERE snapshot_id IN "
@@ -693,7 +694,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 @app.get("/health")
 @limiter.limit("60/minute")
 def health(request: Request) -> dict:
-    return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
+    return {"status": "ok", "timestamp": datetime.now(UTC).isoformat()}
 
 
 @app.post("/snapshots", response_model=SnapshotResponse)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort (import sorting)
+    "UP",    # pyupgrade (modern Python idioms)
+    "B",     # flake8-bugbear (common bugs)
+    "SIM",   # flake8-simplify
+    "RUF",   # ruff-specific rules
+]
+ignore = [
+    "E501",  # line length handled by line-length setting
+    "UP007", # use X | Y for union types (already used)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B011"]  # allow assert in tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from bgp_route_analyzer import init_db
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
-import pytest
 from pathlib import Path
-from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from bgp_route_analyzer import app, init_db, save_snapshot

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import json
-import pytest
 from pathlib import Path
+
+import pytest
 
 from bgp_route_analyzer import _load_routers, _validate_cors_origins
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from bgp_route_analyzer import (
@@ -101,7 +101,7 @@ def test_purge_old_snapshots(test_db: Path):
           "local_pref": "100", "weight": "0", "as_path": "65001", "origin": "i"}]
 
     # Insert a snapshot with old timestamp
-    old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    old_time = (datetime.now(UTC) - timedelta(days=60)).isoformat()
     with sqlite3.connect(test_db) as conn:
         conn.execute(
             "INSERT INTO snapshots (router, captured_at, raw_output) VALUES (?, ?, ?)",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from bgp_route_analyzer import diff_snapshots, init_db, save_snapshot
+from bgp_route_analyzer import diff_snapshots, save_snapshot
 
 
 def _make_prefix(network: str, next_hop: str = "1.1.1.1", **overrides) -> dict:


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI workflow (`.github/workflows/ci.yml`) with lint and test jobs
- Lint job runs ruff, flake8, and mypy on Python 3.13
- Test job runs pytest across Python 3.12 and 3.13 matrix
- Adds `pyproject.toml` with ruff configuration (pycodestyle, pyflakes, isort, pyupgrade, bugbear, simplify rules)
- Fixes all ruff findings: import sorting, `datetime.UTC` alias, unused imports, `zip()` strict parameter

## Test plan
- [ ] Verify CI workflow triggers on this PR
- [ ] Confirm lint job passes (ruff, flake8, mypy)
- [ ] Confirm test job passes on both Python 3.12 and 3.13
- [ ] Verify all 57 tests pass locally before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)